### PR TITLE
Add DPI monitor info for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -772,7 +772,7 @@ endif(SUPPORT_X11 AND NOT ALLEGRO_RASPBERRYPI)
 if(WIN32)
     list(APPEND LIBRARY_SOURCES ${ALLEGRO_SRC_WIN_FILES})
     list(APPEND PLATFORM_LIBS
-        kernel32 user32 gdi32 comdlg32 ole32 winmm psapi shlwapi
+        kernel32 user32 gdi32 comdlg32 ole32 winmm psapi shlwapi Shcore
         )
     if(SUPPORT_D3D)
         list(APPEND LIBRARY_SOURCES ${ALLEGRO_SRC_D3D_FILES})

--- a/docs/src/refman/monitor.txt
+++ b/docs/src/refman/monitor.txt
@@ -14,7 +14,8 @@ Other monitors can have negative values if they are to the
 left or above the primary display. x2, y2 are the
 coordinates one beyond the bottom right pixel, so that
 x2-x1 gives the width and y2-y1 gives the height of the
-display.
+display. dpi will contain dots per inch on the primary
+display, otherwise will be negative.
 
 ~~~~c
 typedef struct ALLEGRO_MONITOR_INFO
@@ -23,6 +24,7 @@ typedef struct ALLEGRO_MONITOR_INFO
    int y1;
    int x2;
    int y2;
+   int dpi;
 } ALLEGRO_MONITOR_INFO;
 ~~~~
 

--- a/docs/src/refman/monitor.txt
+++ b/docs/src/refman/monitor.txt
@@ -15,7 +15,7 @@ left or above the primary display. x2, y2 are the
 coordinates one beyond the bottom right pixel, so that
 x2-x1 gives the width and y2-y1 gives the height of the
 display. dpi will contain dots per inch on the primary
-display, otherwise will be negative.
+display, otherwise will be zero.
 
 ~~~~c
 typedef struct ALLEGRO_MONITOR_INFO

--- a/examples/ex_monitorinfo.c
+++ b/examples/ex_monitorinfo.c
@@ -25,7 +25,7 @@ int main(int argc, char **argv)
    for (i = 0; i < num_adapters; i++) {
       al_get_monitor_info(i, &info);
       log_printf("Adapter %d: ", i);
-      log_printf("(%d, %d) - (%d, %d)\n", info.x1, info.y1, info.x2, info.y2);
+      log_printf("(%d, %d) - (%d, %d) - dpi: %d\n", info.x1, info.y1, info.x2, info.y2, info.dpi);
       al_set_new_display_adapter(i);
       log_printf("   Available fullscreen display modes:\n");
       for (j = 0; j < al_get_num_display_modes(); j++) {

--- a/include/allegro5/monitor.h
+++ b/include/allegro5/monitor.h
@@ -16,6 +16,7 @@ typedef struct ALLEGRO_MONITOR_INFO
    int y1;
    int x2;
    int y2;
+   int dpi;
 } ALLEGRO_MONITOR_INFO;
 
 enum {

--- a/src/macosx/system.m
+++ b/src/macosx/system.m
@@ -383,10 +383,16 @@ static bool osx_get_monitor_info(int adapter, ALLEGRO_MONITOR_INFO* info)
    CGError err = CGGetActiveDisplayList(max_displays, displays, &count);
    if (err == kCGErrorSuccess && adapter >= 0 && adapter < (int) count) {
       CGRect rc = CGDisplayBounds(displays[adapter]);
+      CGSize size = CGDisplayScreenSize(displays[adapter]);
       info->x1 = (int) rc.origin.x;
       info->x2 = (int) (rc.origin.x + rc.size.width);
       info->y1 = (int) rc.origin.y;
       info->y2 = (int) (rc.origin.y + rc.size.height);
+#define INCHES_PER_MM 0.039370
+      int dpi_hori = (info->x2 - info->x1) / (INCHES_PER_MM * size.width);
+      int dpi_vert = (info->y2 - info->y1) / (INCHES_PER_MM * size.height);
+#undef INCHES_PER_MM
+      info->dpi = sqrt(dpi_hori * dpi_vert);
       ALLEGRO_INFO("Display %d has coordinates (%d, %d) - (%d, %d)\n",
          adapter, info->x1, info->y1, info->x2, info->y2);
       return true;

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -38,6 +38,8 @@ bool al_get_monitor_info(int adapter, ALLEGRO_MONITOR_INFO *info)
 {
    ALLEGRO_SYSTEM *system = al_get_system_driver();
 
+   info->dpi = 0;
+
    if (adapter < al_get_num_video_adapters()) {
       if (system && system->vt && system->vt->get_monitor_info) {
          return system->vt->get_monitor_info(adapter, info);

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -44,7 +44,7 @@ bool al_get_monitor_info(int adapter, ALLEGRO_MONITOR_INFO *info)
       }
    }
 
-   info->x1 = info->y1 = info->x2 = info->y2 = INT_MAX;
+   info->x1 = info->y1 = info->x2 = info->y2 = info->dpi = INT_MAX;
    return false;
 }
 

--- a/src/x/xfullscreen.c
+++ b/src/x/xfullscreen.c
@@ -922,6 +922,13 @@ bool _al_xglx_get_monitor_info(ALLEGRO_SYSTEM_XGLX *s, int adapter, ALLEGRO_MONI
       info->y1 = 0;
       info->x2 = DisplayWidth(s->x11display, DefaultScreen(s->x11display));
       info->y2 = DisplayHeight(s->x11display, DefaultScreen(s->x11display));
+      int x2_mm = DisplayWidthMM(s->x11display, DefaultScreen(s->x11display));
+      int y2_mm = DisplayHeightMM(s->x11display, DefaultScreen(s->x11display));
+#define INCHES_PER_MM 0.039370
+      int dpi_hori = (info->x2 - info->x1) / (INCHES_PER_MM * x2_mm);
+      int dpi_vert = (info->y2 - info->y1) / (INCHES_PER_MM * y2_mm);
+#undef INCHES_PER_MM
+      info->dpi = sqrt(dpi_hori * dpi_vert);
       _al_mutex_unlock(&s->lock);
       return true;
    }

--- a/src/x/xrandr.c
+++ b/src/x/xrandr.c
@@ -4,6 +4,8 @@
 #include "allegro5/internal/aintern_xfullscreen.h"
 #include "allegro5/internal/aintern_xsystem.h"
 
+#include <math.h>
+
 #ifdef ALLEGRO_XWINDOWS_WITH_XRANDR
 
 ALLEGRO_DEBUG_CHANNEL("xrandr")
@@ -655,6 +657,12 @@ static bool xrandr_get_monitor_info(ALLEGRO_SYSTEM_XGLX *s, int adapter, ALLEGRO
    mi->y1 = crtc->y;
    mi->x2 = crtc->x + crtc->width;
    mi->y2 = crtc->y + crtc->height;
+#define INCHES_PER_MM 0.039370
+   int dpi_hori = (mi->x2 - mi->x1) / (INCHES_PER_MM * output->mm_width);
+   int dpi_vert = (mi->y2 - mi->y1) / (INCHES_PER_MM * output->mm_height);
+#undef INCHES_PER_MM
+   mi->dpi = sqrt(dpi_hori * dpi_vert);
+
    return true;
 }
 


### PR DESCRIPTION
This adds DPI querying for monitor info on Windows, however the deal breaker is it introduces windows 8.1+ specific libs and headers at build time. With some CMake and preprocessor magic, it can be made optional perhaps.